### PR TITLE
Default to internal-only traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ should run anywhere.
       --set-secrets="GITHUB_TOKEN=ght-proxy-token:1" \
       --set-env-vars="ALLOWED_SCOPES=match:.*" \
       --image="us-docker.pkg.dev/${PROJECT_ID}/ght-proxy/ght-proxy" \
-      --service-account="ght-proxy@${PROJECT_ID}.iam.gserviceaccount.com"
+      --service-account="ght-proxy@${PROJECT_ID}.iam.gserviceaccount.com" \
+      --ingress=internal
     ```
 
     For a GitHub App:
@@ -191,7 +192,8 @@ should run anywhere.
       --set-secrets="GITHUB_APP_PRIVATE_KEY=ght-proxy-app-private-key:1" \
       --set-env-vars="ALLOWED_SCOPES=match:.*,GITHUB_INSTALLATION_ID=${GITHUB_INSTALLATION_ID?},GITHUB_APP_ID=${GITHUB_APP_ID?}" \
       --image="gcr.io/${PROJECT_ID}/ght-proxy" \
-      --service-account="ght-proxy@${PROJECT_ID}.iam.gserviceaccount.com"
+      --service-account="ght-proxy@${PROJECT_ID}.iam.gserviceaccount.com" \
+      --ingress=internal
     ```
 
 


### PR DESCRIPTION
The use case for this proxy is likely to be within the same cloud
project, so this seems like a better default and is more secure. The
quick setup guide already makes opinionated decisions (like naming) and
creates everything in one cloud project, so someone who wanted to
diverge from this would already need to modify other steps as well.

Signed-off-by: Geoffrey Martin-Noble <gcmn@google.com>
